### PR TITLE
refactor: Get wavelength from atlasStat.probe instead of run snirf inside function loadSen()

### DIFF
--- a/GUI/ExternalWindow/SSDOTPipelineWindow.m
+++ b/GUI/ExternalWindow/SSDOTPipelineWindow.m
@@ -105,7 +105,9 @@ classdef SSDOTPipelineWindow < handle
             
             fprintf('Pipeline window created successfully!\n');
         end
-        
+
+
+        %% CREATE UI
         function createPropertyStatusPanel(obj)
             % Property status panel that can scrollable
             obj.PropertyPanel = uipanel(obj.MainGrid, ...
@@ -399,7 +401,7 @@ classdef SSDOTPipelineWindow < handle
             obj.StatusLabel.Layout.Column = 2;
         end
         
-        
+        %% 
         function onConfigChanged(obj)
             if isempty(obj.ssdot) || ~isvalid(obj.ssdot)
                 return;
@@ -425,7 +427,9 @@ classdef SSDOTPipelineWindow < handle
             
             % Update ssdot
             obj.ssdot.setVar('cfg', cfg);
-            
+
+
+            % debug
             fprintf('Config updated: device=%s, reg=%d, alpha=%.4f, beta=%.4f, thresh_sens=%.2f, spatial_regu=%d, th_brain=%.2f, th_scalp=%.2f, sigma_brain=%.2f, sigma_scalp=%.2f\n', ...
                 cfg.device, cfg.regularization, cfg.alpha, cfg.beta, ...
                 cfg.threshold_sensitivity, cfg.spatially_regu, ...
@@ -446,7 +450,7 @@ classdef SSDOTPipelineWindow < handle
                         if ~isempty(val)
                             lamp.Color = 'green';
                         else
-                            lamp.Color = [0.7 0.7 0.7];
+                            lamp.Color = [0.7 0.7 0.7]; %gray
                         end
                     else
                         lamp.Color = [0.7 0.7 0.7];
@@ -483,6 +487,30 @@ classdef SSDOTPipelineWindow < handle
             end
             
             button.Enable = 'on';
+        end
+
+        function updateBtnTips(obj)
+            %tips for disable button, update constantly after user load something
+            %tips with require fields
+            tips = {
+                obj.ButtonDisplaySD, {'AtlasState'};
+                obj.ButtonLoadSens, {'AtlasState', 'selectedRun'}
+            };
+
+            for i = 1:numel(tips(:,1))
+                button = tips{i,1};
+                reqFields = tips{i,2};
+
+                if (button.Enable == "off" && ~isempty(reqFields))
+                    missing = {};
+                    for j = 1:numel(reqFields)
+                        if isempty(obj.ssdot.(reqFields{j}))
+                            missing{end+1} = reqFields{j};
+                        end
+                    end
+                    button.Tooltip = sprintf('Missing: %s\nComplete previous steps first.', strjoin(missing, ', '));
+                end
+            end
         end
         
         %%  helper
@@ -606,6 +634,7 @@ classdef SSDOTPipelineWindow < handle
             obj.canEnable(obj.ButtonRunRecon, 'A', 'G', 'Y', 'T', 'OD_SS', 'OD_drift', 'AtlasState');
             
             obj.updatePropertyLamps();
+            obj.updateBtnTips();
         end
 
 

--- a/GUI/FunctionForGUI/generate_spatial_base.m
+++ b/GUI/FunctionForGUI/generate_spatial_base.m
@@ -6,7 +6,7 @@ atlasViewer = ssdot.getVar('AtlasState');
 % Sensitivity_Matrix = get_global_variable(app, 'Sensitivity_Matrix');
 Sensitivity_Matrix = ssdot.getVar('Sensitivity_Matrix');
 
-ssdot.setVar('cfg', cfg);
+cfg = ssdot.getVar('cfg');
 
 G = Make_G_matrix(atlasViewer, Sensitivity_Matrix.M, ...
     cfg.threshold_brain, cfg.threshold_scalp, cfg.sigma_brain, cfg.sigma_scalp, ...

--- a/GUI/FunctionForGUI/loadSens.m
+++ b/GUI/FunctionForGUI/loadSens.m
@@ -14,13 +14,10 @@ mlActAuto = []; % we need to do something here later
 % atlasViewer = get_global_variable(app, 'AtlasState');
 atlasViewer = ssdot.getVar('AtlasState');
 % wavelength = [760 850]; % Vu we need users to input this or we get this information from snirf
-run1 = ssdot.getVar('selectedRun');
-wavelength = run1.GetWls();
-%% Prompt the user for a mask threshold value
-% prompt = {'Enter threshold of sensitivity'};
-% dlgtitle = 'Input Threshold';
-% dims = [1 35];
-% definput = {'-2'};  % Default value
+% run1 = ssdot.getVar('selectedRun');
+% wavelength = run1.GetWls();
+wavelength = atlasViewer.probe.lambda; %!!! i also found wavelength(lambda) inside probe!!!
+
 
 % answer = inputdlg(prompt, dlgtitle, dims, definput);
 cfg = ssdot.getVar('cfg');


### PR DESCRIPTION
Im tidying up how we get the wavelength number when we run the `loadSensitivity` function

Previous: Wavelength was retrieved  from `run snirf`
Now: Wavelength is now retrieved directly from `atlasState.probe.lambda`

goal: We no longer need to rely on the `run snirf` process simply to get the wavelength data, making `loadSensitivity`  more robust.

Other: add some comment in code, fix small error missing cfg

